### PR TITLE
Allow Usage with GHE

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Setup pom.xml in project
 
 | Parameter       | Required | Default Value                | Description                                                                                                                       |
 |-----------------|----------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| baseUri         | false    | https://api.github.com       | The API endpoint - generally only used with GitHub Enterprise                                                                     |
 | owner           | true     | <>                           | The name of the owner of the targeted repository                                                                                  |
 | repository      | true     | <>                           | The name of the targeted repository                                                                                               |
 | server          | false    | <>                           | References a server configuration in your .m2 settings.xml. This is the preferred way for using the GitHub Api token              |

--- a/src/main/java/com/ragedunicorn/tools/maven/GitHubClient.java
+++ b/src/main/java/com/ragedunicorn/tools/maven/GitHubClient.java
@@ -39,7 +39,7 @@ public class GitHubClient {
   public static final String GITHUB_MEDIA_TYPE = "application/vnd.github.v3+json";
 
   // github api base url
-  private static final String baseUri = "https://api.github.com";
+  private String baseUri = "https://api.github.com";
   // targeted repository
   private String repository;
   // owner of the repository
@@ -47,8 +47,12 @@ public class GitHubClient {
   // oauth token
   private String token;
 
-  public static String getBaseUri() {
+  public String getBaseUri() {
     return baseUri;
+  }
+
+  public void setBaseUri(String baseUri) {
+    this.baseUri = baseUri;
   }
 
   public String getRepository() {

--- a/src/main/java/com/ragedunicorn/tools/maven/GitHubReleaseMojo.java
+++ b/src/main/java/com/ragedunicorn/tools/maven/GitHubReleaseMojo.java
@@ -42,6 +42,10 @@ public class GitHubReleaseMojo extends AbstractMojo {
   private Boolean skip;
 
   // owner of the repository
+  @Parameter(property = "baseUri", required = false)
+  private String baseUri;
+
+  // owner of the repository
   @Parameter(property = "owner", required = true)
   private String owner;
 
@@ -210,6 +214,12 @@ public class GitHubReleaseMojo extends AbstractMojo {
    */
   private GitHubClient createGitHubClient() throws MojoExecutionException {
     GitHubClient gitHubClient = new GitHubClient();
+    if (baseUri != null) {
+      if (baseUri.endsWith("/")) {
+        baseUri = baseUri.substring(0, baseUri.length()-1);
+      }
+      gitHubClient.setBaseUri(baseUri);
+    }
     gitHubClient.setOAuthToken(getCredentials());
     gitHubClient.setRepository(repository);
     gitHubClient.setOwner(owner);


### PR DESCRIPTION
Allow the `baseUri` to be updated so one can release to GitHub Enterprise.