### PR TITLE
Add ability to use GitHub's automated release notes generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Setup pom.xml in project
               <targetCommitish>master</targetCommitish>
               <body>release description overwritten by release notes</body>
               <releaseNotes>src/main/resources/release-notes-example.md</releaseNotes>
+              <generateReleaseNotes>false</generateReleaseNotes>
               <assets>
                 <asset>src/main/resources/asset-plain-text-example.txt</asset>
                 <asset>src/main/resources/asset-zip-example.zip</asset>
@@ -43,21 +44,22 @@ Setup pom.xml in project
 </project>
 ```
 
-| Parameter       | Required | Default Value                | Description                                                                                                                       |
-|-----------------|----------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| baseUri         | false    | https://api.github.com       | The API endpoint - generally only used with GitHub Enterprise                                                                     |
-| owner           | true     | <>                           | The name of the owner of the targeted repository                                                                                  |
-| repository      | true     | <>                           | The name of the targeted repository                                                                                               |
-| server          | false    | <>                           | References a server configuration in your .m2 settings.xml. This is the preferred way for using the GitHub Api token              |
-| authToken       | false    | <>                           | Alternative of using a server configuration. The authToken can directly be placed in the plugin configuration                     |
-| tagName         | true     | <>                           | The full name of the tag that should get used to create the release                                                               |
-| name            | false    | [tagname]                    | The title of the release                                                                                                          |
-| targetCommitish | false    | master                       | Determines where the tag is created from if the tag does not already exist. It is usually better to create a tag first            |
-| body            | false    | [commit message last commit] | The body of the release. Essentially the release notes. Text is taken as is. For easier formatting use the releaseNotes parameter |
-| releaseNotes    | false    | <>                           | Overwrite body parameter. A file containing the text for the release notes                                                        |
-| assets          | false    | <>                           | A list of files that are being uploaded and attached to the release                                                               |
-| draft           | false    | false                        | True to create a draft (unpublished) release, false to create a published one                                                     |
-| skip            | false    | false                        | True for skipping the plugin                                                                                                      |
+| Parameter              | Required | Default Value                | Description                                                                                                                                           |
+|------------------------|----------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| baseUri                | false    | https://api.github.com       | The API endpoint - generally only used with GitHub Enterprise                                                                                         |
+| owner                  | true     | <>                           | The name of the owner of the targeted repository                                                                                                      |
+| repository             | true     | <>                           | The name of the targeted repository                                                                                                                   |
+| server                 | false    | <>                           | References a server configuration in your .m2 settings.xml. This is the preferred way for using the GitHub Api token                                  |
+| authToken              | false    | <>                           | Alternative of using a server configuration. The authToken can directly be placed in the plugin configuration                                         |
+| tagName                | true     | <>                           | The full name of the tag that should get used to create the release                                                                                   |
+| name                   | false    | [tagname]                    | The title of the release                                                                                                                              |
+| targetCommitish        | false    | master                       | Determines where the tag is created from if the tag does not already exist. It is usually better to create a tag first                                |
+| body                   | false    | [commit message last commit] | The body of the release. Essentially the release notes. Text is taken as is. For easier formatting use the releaseNotes parameter                     |
+| releaseNotes           | false    | <>                           | Overwrite body parameter. A file containing the text for the release notes                                                                            |
+| generateReleaseNotes   | false    | <>                           | When true, github will automatically generate release notes.  If body/releaseNotes also specified, then they will be prepended to the generated notes |
+| assets                 | false    | <>                           | A list of files that are being uploaded and attached to the release                                                                                   |
+| draft                  | false    | false                        | True to create a draft (unpublished) release, false to create a published one                                                                         |
+| skip                   | false    | false                        | True for skipping the plugin                                                                                                                          |
 
 ### Execute Plugin
 

--- a/src/main/java/com/ragedunicorn/tools/maven/GitHubReleaseMojo.java
+++ b/src/main/java/com/ragedunicorn/tools/maven/GitHubReleaseMojo.java
@@ -81,6 +81,11 @@ public class GitHubReleaseMojo extends AbstractMojo {
   @Parameter(property = "releaseNotes")
   private String releaseNotes;
 
+  // true to generate release notes automatically - if body/releaseNotes are also specified,
+  // they will be prepended to the generated release notes
+  @Parameter(property = "generateReleaseNotes")
+  private Boolean generateReleaseNotes;
+
   // a list of assets such as .zip to attach to the release
   @Parameter(property = "assets")
   private String[] assets;
@@ -137,6 +142,7 @@ public class GitHubReleaseMojo extends AbstractMojo {
     release.setName(name);
     release.setBody(body);
     release.setReleaseNotes(releaseNotes);
+    release.setGenerateReleaseNotes(generateReleaseNotes);
     release.setDraft(draft);
     release.setPrerelease(prerelease);
 

--- a/src/main/java/com/ragedunicorn/tools/maven/model/Release.java
+++ b/src/main/java/com/ragedunicorn/tools/maven/model/Release.java
@@ -43,6 +43,10 @@ public class Release {
 
   private String releaseNotes;
 
+  @SerializedName("generate_release_notes")
+  @Expose
+  private Boolean generateReleaseNotes;
+
   @Expose
   private Boolean draft;
 
@@ -89,6 +93,14 @@ public class Release {
     this.releaseNotes = releaseNotes;
   }
 
+  public Boolean getGenerateReleaseNotes() {
+    return generateReleaseNotes;
+  }
+
+  public void setGenerateReleaseNotes(Boolean generateReleaseNotes) {
+    this.generateReleaseNotes = generateReleaseNotes;
+  }
+
   public Boolean getDraft() {
     return draft;
   }
@@ -113,6 +125,7 @@ public class Release {
         + ", name='" + name + '\''
         + ", body='" + body + '\''
         + ", releaseNotes='" + releaseNotes + '\''
+        + ", generateReleaseNotes='" + generateReleaseNotes + '\''
         + ", draft=" + draft
         + ", prerelease=" + prerelease
         + '}';
@@ -132,12 +145,13 @@ public class Release {
         && Objects.equals(name, release.name)
         && Objects.equals(body, release.body)
         && Objects.equals(releaseNotes, release.releaseNotes)
+        && Objects.equals(generateReleaseNotes, release.generateReleaseNotes)
         && Objects.equals(draft, release.draft)
         && Objects.equals(prerelease, release.prerelease);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tagName, targetCommitish, name, body, releaseNotes, draft, prerelease);
+    return Objects.hash(tagName, targetCommitish, name, body, releaseNotes, generateReleaseNotes, draft, prerelease);
   }
 }

--- a/src/main/java/com/ragedunicorn/tools/maven/service/ReleaseService.java
+++ b/src/main/java/com/ragedunicorn/tools/maven/service/ReleaseService.java
@@ -155,11 +155,13 @@ public class ReleaseService {
       release.setTargetCommitish("master");
     }
 
-    if (release.getName() == null || release.getName().isEmpty()) {
+    if ((release.getName() == null || release.getName().isEmpty())
+            && !Boolean.TRUE.equals(release.getGenerateReleaseNotes())) {
       release.setName("");
     }
 
-    if (release.getBody() == null || release.getBody().isEmpty()) {
+    if ((release.getBody() == null || release.getBody().isEmpty())
+            && !Boolean.TRUE.equals(release.getGenerateReleaseNotes())) {
       release.setBody("");
     }
 
@@ -174,6 +176,10 @@ public class ReleaseService {
     if (release.getReleaseNotes() != null) {
       logger.debug("Overwriting body with release notes file content");
       release.setBody(loadReleaseNotes(release.getReleaseNotes()));
+    }
+
+    if (release.getGenerateReleaseNotes() == null) {
+      release.setGenerateReleaseNotes(false);
     }
 
     return release;


### PR DESCRIPTION
Added a new `generateReleaseNotes` boolean parameter (Default false). When true, it will cause GitHub to automatically generate the release notes.

See [GitHub Docs](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release)
